### PR TITLE
fix: don't change working dir

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,9 @@
+.idea
 node_modules
 yarn*
 *.ts
+!index.d.ts
 tsconfig.json
+
+# don't include the top-level, source schemas. Only the ones in the build dir
+/schemas

--- a/index.ts
+++ b/index.ts
@@ -2,12 +2,12 @@ import * as mod from 'validate-with-xmllint';
 import * as path from 'path';
 
 const xsd = 'saml-schema-protocol-2.0.xsd';
+const fullXsdPath = path.resolve(__dirname, 'schemas', xsd);
 
-export const validate = (xml: string) => {
+export const validate = (xml: string): Promise<string> => {
   return new Promise((resolve, reject) => {
-    process.chdir(path.resolve(__dirname, './schemas'));
-    mod.validateXMLWithXSD(xml, xsd)
-      .then((result: any) => {
+    mod.validateXMLWithXSD(xml, fullXsdPath)
+      .then(() => {
         return resolve('SUCCESS_VALIDATE_XML');
       }, (err: any) => {
         console.error('[ERROR] validateXML', err);


### PR DESCRIPTION
Pass the absolute path of the XSD to `xmllint` instead of changing the cwd of the entire Node process. 
Also updated .npmignore to include the index.d.ts and not double include the schamas in the pack.

Fixes #2, fixes #3

@tngan 