### PR TITLE
Specify `types` in `package.json`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 node_modules
 yarn*
 *.ts
+!*.d.ts
 tsconfig.json

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "Validator module powered by validate-with-xmllint",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "build": "yarn run clean && yarn run cp-schemas && tsc",
     "cp-schemas": "mkdir -p build/schemas && cp -R schemas build",


### PR DESCRIPTION
Using this package in a Typescript project currently requires adding a module declaration because the package does not provide any types.

This should fix that.